### PR TITLE
Fix 'dot_sourcepath' for relative path

### DIFF
--- a/pylint/graph.py
+++ b/pylint/graph.py
@@ -82,19 +82,13 @@ class DotBackend:
         :return: a path to the generated file
         """
         name = self.graphname
-        if not dotfile:
-            # if 'outputfile' is a dot file use it as 'dotfile'
-            if outputfile and outputfile.endswith(".dot"):
-                dotfile = outputfile
-            else:
-                dotfile = "%s.dot" % name
         if outputfile is not None:
-            storedir, _, target = target_info_from_filename(outputfile)
+            _, _, target = target_info_from_filename(outputfile)
             if target != "dot":
                 pdot, dot_sourcepath = tempfile.mkstemp(".dot", name)
                 os.close(pdot)
             else:
-                dot_sourcepath = osp.join(storedir, dotfile)
+                dot_sourcepath = outputfile
         else:
             target = "png"
             pdot, dot_sourcepath = tempfile.mkstemp(".dot", name)


### PR DESCRIPTION
While playing around with the 'import-graph' setting, I noticed that attempting to write a graph to a local directory did not work as I would have expected.
For example, 'import-graph=docs/graph.dot' would attempt to add 'graph.dot' to '/LOCAL/PATH/docs/docs/'.
This was because the 'dot_sourcepath' in this scenario would be set to the combination of the 'storedir' ('/LOCAL/PATH/docs') and the 'outputfile' ('docs/graph.dot'). I am requesting that it be changed to just be 'outputfile' in this scenario.

Also, I have removed the instantiation of the 'dotfile' variable because it now has no use.

<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.

## Description


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
| ✓  | :hammer: Refactoring  |
| ✓  | :scroll: Docs |

## Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
